### PR TITLE
[Week6] - SwiftUI로 취미 조회 뷰 재구성하기

### DIFF
--- a/35-seminar.xcodeproj/project.pbxproj
+++ b/35-seminar.xcodeproj/project.pbxproj
@@ -75,6 +75,7 @@
 		15EC305D2CCB792300A0480B /* FeedbackWriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC305C2CCB792300A0480B /* FeedbackWriteViewController.swift */; };
 		15EC305F2CCB793500A0480B /* FeedbackWriteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC305E2CCB793500A0480B /* FeedbackWriteView.swift */; };
 		15EC30612CCB8E9C00A0480B /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EC30602CCB8E9C00A0480B /* Date+Extension.swift */; };
+		15EECEBB2CF9856100E3FAA2 /* SUHobbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EECEBA2CF9856100E3FAA2 /* SUHobbyView.swift */; };
 		15F4FD072CC73D0A00C99A20 /* StarStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F4FD062CC73D0A00C99A20 /* StarStackView.swift */; };
 		15F4FD0F2CC7649A00C99A20 /* BorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F4FD0E2CC7649A00C99A20 /* BorderView.swift */; };
 		15F923B22CE2088900B6F49A /* HobbyTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F923B12CE2088900B6F49A /* HobbyTableViewHeader.swift */; };
@@ -163,6 +164,7 @@
 		15EC305C2CCB792300A0480B /* FeedbackWriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackWriteViewController.swift; sourceTree = "<group>"; };
 		15EC305E2CCB793500A0480B /* FeedbackWriteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackWriteView.swift; sourceTree = "<group>"; };
 		15EC30602CCB8E9C00A0480B /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
+		15EECEBA2CF9856100E3FAA2 /* SUHobbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SUHobbyView.swift; sourceTree = "<group>"; };
 		15F4FD062CC73D0A00C99A20 /* StarStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarStackView.swift; sourceTree = "<group>"; };
 		15F4FD0E2CC7649A00C99A20 /* BorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderView.swift; sourceTree = "<group>"; };
 		15F923B12CE2088900B6F49A /* HobbyTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HobbyTableViewHeader.swift; sourceTree = "<group>"; };
@@ -530,6 +532,7 @@
 			isa = PBXGroup;
 			children = (
 				15EAC4602CDD4FB500419E14 /* SocialView.swift */,
+				15EECEBA2CF9856100E3FAA2 /* SUHobbyView.swift */,
 				15F923B32CE2166B00B6F49A /* AccountView.swift */,
 				15EAC4862CDE6A5A00419E14 /* HobbyView.swift */,
 				15EAC4842CDE605500419E14 /* HobbyTableViewCell.swift */,
@@ -712,6 +715,7 @@
 				1590A6A42CBE8A9200FB32AE /* DetailViewController.swift in Sources */,
 				1590A6422CBE6C6A00FB32AE /* Week1DetailView.swift in Sources */,
 				15EAC47C2CDE282A00419E14 /* RegisterView.swift in Sources */,
+				15EECEBB2CF9856100E3FAA2 /* SUHobbyView.swift in Sources */,
 				15F9EE132CD6072B00172E82 /* Week4LoginViewController.swift in Sources */,
 				157119DA2CBE96BB00362252 /* ContentLabel.swift in Sources */,
 				15EAC4792CDDF0E400419E14 /* LoginStatus.swift in Sources */,

--- a/35-seminar/Application/SceneDelegate.swift
+++ b/35-seminar/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = LoginViewController()
+        let navigationController = SocialViewController()
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/35-seminar/Application/SceneDelegate.swift
+++ b/35-seminar/Application/SceneDelegate.swift
@@ -14,7 +14,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         self.window = UIWindow(windowScene: windowScene)
-        let navigationController = SocialViewController()
+        let navigationController = UINavigationController(rootViewController: SocialViewController())
         self.window?.rootViewController = navigationController
         self.window?.makeKeyAndVisible()
     }

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -19,45 +19,47 @@ struct SUHobbyView: View {
     private let pageSize = 30
 
     var body: some View {
-        List {
-            // 나의 취미 섹션
-            Section(
-                header: SUHobbyHeaderView(
-                    sectionTitle: "나의 취미",
-                    columnTitles: nil)
-            ) {
-                if userHobby.isEmpty {
-                    Text("취미 정보를 불러오는 중...")
-                        .foregroundColor(.gray)
-                } else {
-                    Text(userHobby)
-                }
-            }
-            
-            // 친구들의 취미 섹션
-            Section(header: SUHobbyHeaderView(
-                sectionTitle: "친구들의 취미",
-                columnTitles: ["id", "취미"])
-            ) {
-                ForEach(hobbies, id: \.0) { (no, hobby) in
-                    HStack {
-                        Text("\(no)").frame(width: 30)
-                        Text(hobby)
+        ScrollViewReader { proxy in
+            List {
+                // 나의 취미 섹션
+                Section(
+                    header: SUHobbyHeaderView(
+                        sectionTitle: "나의 취미",
+                        columnTitles: nil)
+                ) {
+                    if userHobby.isEmpty {
+                        Text("취미 정보를 불러오는 중...")
+                            .foregroundColor(.gray)
+                    } else {
+                        Text(userHobby)
                     }
                 }
                 
-                if hasMoreData {
-                    HStack {
-                        Spacer()
-                        ProgressView()
-                            .onAppear {
-                                loadMoreHobbies()
-                            }
-                        Spacer()
+                // 친구들의 취미 섹션
+                Section(header: SUHobbyHeaderView(
+                    sectionTitle: "친구들의 취미",
+                    columnTitles: ["id", "취미"])
+                ) {
+                    ForEach(hobbies, id: \.0) { (no, hobby) in
+                        HStack {
+                            Text("\(no)").frame(width: 30)
+                            Text(hobby)
+                        }
+                    }
+                    
+                    // TODO: onChange 메소드에 넣기
+                    if hasMoreData {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .onAppear {
+                                    loadMoreHobbies()
+                                }
+                            Spacer()
+                        }
                     }
                 }
             }
-            
         }
         .onAppear {
             fetchUserHobby()

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -6,3 +6,116 @@
 //
 
 import SwiftUI
+
+struct SUHobbyView: View {
+    @State private var userHobby: String = "축구"
+    @State private var hobbies: [(Int, String)] = [
+        (1, "영화 보기"), (2, "야구장 가기")
+    ]
+    @State private var currentUserNo = 1
+    @State private var isFetching = false
+    @State private var hasMoreData = true
+    
+    private let pageSize = 30
+
+    var body: some View {
+        ScrollViewReader { scrollProxy in
+            List {
+                // 나의 취미 섹션
+                Section(
+                    header: Text("나의 취미")
+                        .font(.caption)
+                        .foregroundColor(.secondary)) {
+                            if userHobby.isEmpty {
+                                Text("취미 정보를 불러오는 중...")
+                                    .foregroundColor(.gray)
+                            } else {
+                                Text(userHobby)
+                            }
+                        }
+                
+                // 친구들의 취미 섹션
+                Section(header: HStack {
+                    Text("no").frame(width: 30)
+                    Text("취미").fontWeight(.medium)
+                }) {
+                    ForEach(hobbies, id: \.0) { (no, hobby) in
+                        HStack {
+                            Text("\(no)").frame(width: 30)
+                            Text(hobby)
+                        }
+                    }
+                    
+                    if hasMoreData {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .onAppear {
+                                    loadMoreHobbies()
+                                }
+                            Spacer()
+                        }
+                    }
+                }
+            }
+            .listStyle(InsetGroupedListStyle())
+            .onAppear {
+                fetchUserHobby()
+            }
+        }
+    }
+    
+    // 유저 취미 데이터를 로드하는 함수
+    private func fetchUserHobby() {
+        UserService.shared.fetchUserHobby(token: UserDefaultsManager.fetchUserData().token) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let hobby):
+                    self.userHobby = hobby
+                case .failure(let error):
+                    print("hobby 조회 에러: \(error.errorMessage)")
+                }
+            }
+        }
+    }
+    
+    // 더 많은 취미 데이터를 로드하는 함수
+    private func loadMoreHobbies() {
+        guard !isFetching, hasMoreData else { return }
+        isFetching = true
+        
+        let nextUserNos = (currentUserNo..<(currentUserNo + pageSize)).map { $0 }
+        let dispatchGroup = DispatchGroup()
+        var newHobbies: [(Int, String)] = []
+        var successfulFetches = 0
+        
+        for userNo in nextUserNos {
+            dispatchGroup.enter()
+            UserService.shared.fetchOtherHobby(token: UserDefaultsManager.fetchUserData().token, no: userNo) { result in
+                switch result {
+                case .success(let hobby):
+                    newHobbies.append((userNo, hobby))
+                    successfulFetches += 1
+                case .failure(let error):
+                    print("유저 \(userNo)의 취미를 가져오지 못했습니다. error: \(error)")
+                }
+                dispatchGroup.leave()
+            }
+        }
+        
+        dispatchGroup.notify(queue: .main) {
+            isFetching = false
+            if successfulFetches == 0 {
+                hasMoreData = false
+                return
+            }
+            
+            hobbies.append(contentsOf: newHobbies.sorted { $0.0 < $1.0 })
+            currentUserNo += successfulFetches
+        }
+    }
+}
+
+#Preview {
+    SUHobbyView()
+}

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -79,7 +79,7 @@ struct SUHobbyView: View {
         }
     }
     
-    // 더 많은 취미 데이터를 로드하는 함수
+    // 친구들의 취미 데이터를 로드하는 함수
     private func loadMoreHobbies() {
         guard !isFetching, hasMoreData else { return }
         isFetching = true

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -1,0 +1,8 @@
+//
+//  SUHobbyView.swift
+//  35-seminar
+//
+//  Created by 김유림 on 11/29/24.
+//
+
+import SwiftUI

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -19,49 +19,47 @@ struct SUHobbyView: View {
     private let pageSize = 30
 
     var body: some View {
-        ScrollViewReader { scrollProxy in
-            List {
-                // 나의 취미 섹션
-                Section(
-                    header: Text("나의 취미")
-                        .font(.caption)
-                        .foregroundColor(.secondary)) {
-                            if userHobby.isEmpty {
-                                Text("취미 정보를 불러오는 중...")
-                                    .foregroundColor(.gray)
-                            } else {
-                                Text(userHobby)
-                            }
-                        }
-                
-                // 친구들의 취미 섹션
-                Section(header: HStack {
-                    Text("no").frame(width: 30)
-                    Text("취미").fontWeight(.medium)
-                }) {
-                    ForEach(hobbies, id: \.0) { (no, hobby) in
-                        HStack {
-                            Text("\(no)").frame(width: 30)
-                            Text(hobby)
+        List {
+            // 나의 취미 섹션
+            Section(
+                header: Text("나의 취미")
+                    .font(.caption)
+                    .foregroundColor(.secondary)) {
+                        if userHobby.isEmpty {
+                            Text("취미 정보를 불러오는 중...")
+                                .foregroundColor(.gray)
+                        } else {
+                            Text(userHobby)
                         }
                     }
-                    
-                    if hasMoreData {
-                        HStack {
-                            Spacer()
-                            ProgressView()
-                                .onAppear {
-                                    loadMoreHobbies()
-                                }
-                            Spacer()
-                        }
+            
+            // 친구들의 취미 섹션
+            Section(header: HStack {
+                Text("no").frame(width: 30)
+                Text("취미").fontWeight(.medium)
+            }) {
+                ForEach(hobbies, id: \.0) { (no, hobby) in
+                    HStack {
+                        Text("\(no)").frame(width: 30)
+                        Text(hobby)
+                    }
+                }
+                
+                if hasMoreData {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                            .onAppear {
+                                loadMoreHobbies()
+                            }
+                        Spacer()
                     }
                 }
             }
-            .listStyle(InsetGroupedListStyle())
-            .onAppear {
-                fetchUserHobby()
-            }
+        }
+        .listStyle(InsetGroupedListStyle())
+        .onAppear {
+            fetchUserHobby()
         }
     }
     

--- a/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
+++ b/35-seminar/Presentation/Appstore/User/View/SUHobbyView.swift
@@ -22,22 +22,23 @@ struct SUHobbyView: View {
         List {
             // 나의 취미 섹션
             Section(
-                header: Text("나의 취미")
-                    .font(.caption)
-                    .foregroundColor(.secondary)) {
-                        if userHobby.isEmpty {
-                            Text("취미 정보를 불러오는 중...")
-                                .foregroundColor(.gray)
-                        } else {
-                            Text(userHobby)
-                        }
-                    }
+                header: SUHobbyHeaderView(
+                    sectionTitle: "나의 취미",
+                    columnTitles: nil)
+            ) {
+                if userHobby.isEmpty {
+                    Text("취미 정보를 불러오는 중...")
+                        .foregroundColor(.gray)
+                } else {
+                    Text(userHobby)
+                }
+            }
             
             // 친구들의 취미 섹션
-            Section(header: HStack {
-                Text("no").frame(width: 30)
-                Text("취미").fontWeight(.medium)
-            }) {
+            Section(header: SUHobbyHeaderView(
+                sectionTitle: "친구들의 취미",
+                columnTitles: ["id", "취미"])
+            ) {
                 ForEach(hobbies, id: \.0) { (no, hobby) in
                     HStack {
                         Text("\(no)").frame(width: 30)
@@ -56,8 +57,8 @@ struct SUHobbyView: View {
                     }
                 }
             }
+            
         }
-        .listStyle(InsetGroupedListStyle())
         .onAppear {
             fetchUserHobby()
         }
@@ -113,6 +114,28 @@ struct SUHobbyView: View {
         }
     }
 }
+
+struct SUHobbyHeaderView: View {
+    let sectionTitle: String
+    let columnTitles: [String]?
+    
+    var body: some View {
+        VStack {
+            Text(sectionTitle)
+                .font(.system(size: 17, weight: .semibold))
+            
+            HStack {
+                if let titles = columnTitles {
+                    ForEach(titles, id: \.self) { column in
+                        Text(column)
+                            .frame(width: 30, alignment: .leading)
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 #Preview {
     SUHobbyView()

--- a/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
+++ b/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
@@ -63,7 +63,7 @@ class SocialViewController: BaseViewController {
 //        self.navigationController?.pushViewController(hobbyVC, animated: true)
         
         let vc = UIHostingController(rootView: SUHobbyView())
-        self.present(vc, animated: true)
+        self.navigationController?.pushViewController(vc, animated: true)
     }
 }
 

--- a/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
+++ b/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
@@ -62,6 +62,7 @@ class SocialViewController: BaseViewController {
 //        let hobbyVC = HobbyViewController()
 //        self.navigationController?.pushViewController(hobbyVC, animated: true)
         
+        // SwiftUI로 작성한 뷰를 push
         let vc = UIHostingController(rootView: SUHobbyView())
         self.navigationController?.pushViewController(vc, animated: true)
     }

--- a/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
+++ b/35-seminar/Presentation/Appstore/User/ViewController/SocialViewController.swift
@@ -5,6 +5,7 @@
 //  Created by 김유림 on 11/8/24.
 //
 
+import SwiftUI
 import UIKit
 
 class SocialViewController: BaseViewController {
@@ -58,8 +59,11 @@ class SocialViewController: BaseViewController {
     }
     
     @objc func tappedHobbyButton() {
-        let hobbyVC = HobbyViewController()
-        self.navigationController?.pushViewController(hobbyVC, animated: true)
+//        let hobbyVC = HobbyViewController()
+//        self.navigationController?.pushViewController(hobbyVC, animated: true)
+        
+        let vc = UIHostingController(rootView: SUHobbyView())
+        self.present(vc, animated: true)
     }
 }
 


### PR DESCRIPTION
## 🔍 What is the PR? 
- 6주차 과제로, 취미 조회 뷰를 SwiftUI로 재구현했습니다.

###  💭 Related Issues
#20 

### 📝 구현 내용
**✅ 필수 구현**
- [x] HobbyView를 SwiftUI로 구현
- [x] SocialVC에서 SUHobbyView를 push


### 📷 Screenshot 
|    UIKit    |   SwiftUI   |
| :-------------: | :----------: |
|  <img src = "https://github.com/user-attachments/assets/3fd94a65-8043-4d1b-a3c0-ee42a464bdcd" width ="220"> | <img src = "https://github.com/user-attachments/assets/4990164f-16ed-4579-91fd-29f43962f44b" width ="220"> |



## 😎 Points
### 1️⃣ @State 키워드
- 뷰 내부에서 특정 View 의 상태를 나타내는 변수
- 뷰내부에서 밖에 사용이 불가능함 때문에 private로 선언
- 하위 뷰나 다른 뷰에서 참조하기 위해선 @Binding 해야함
- state property에 해당하는 변수 값이 변경되면 view를 다시 랜더링한다.
  > 때문에 항상 최신값을 가진다.
- 뷰전체가 다시 랜더링 되는일을 막기위해 하위뷰로 데이터 변동이 반영되는 뷰만 따로 빼준다.
  > 따로 뺀 뷰에 state property 를 binding 해준다.
출처: https://huniroom.tistory.com/entry/SwiftUI-state-property [Tunko Development Diary:티스토리]

<details>
<summary> 코드 보기</summary>

```swift
struct SUHobbyView: View {
    @State private var userHobby: String = "축구"
    @State private var hobbies: [(Int, String)] = [
        (1, "영화 보기"), (2, "야구장 가기")
    ]
    @State private var currentUserNo = 1
    @State private var isFetching = false
    @State private var hasMoreData = true
```

</details>


### 2️⃣ 네트워킹 문제
왠진 모르겠는데 POST 작업이 안 되고 있음. Postman에서도 안 됨..
그래서 변수에 임시 데이터를 넣어둠

<details>
<summary> 코드 보기</summary>

```swift
    @State private var userHobby: String = "축구"
    @State private var hobbies: [(Int, String)] = [
        (1, "영화 보기"), (2, "야구장 가기")
    ]
```
</details>


## 🙏 To Reviewers 
- 피드백 환영입니다. 감사합니다!
